### PR TITLE
Repo name changed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# Laravel-on-Magento2
+# Magento2-On-Laravel
 Rurning Magento2 on Laravel Laravel5.1.23 (LTS)


### PR DESCRIPTION
Repo name changed form Laravel-On-Magento2 to Magento2-On-Laravel
